### PR TITLE
use bbolt for local data storage

### DIFF
--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -28,10 +28,6 @@ var loginCmd = &cobra.Command{
 func runLogin(cmd *cobra.Command, args []string) {
 	reader := bufio.NewReader(os.Stdin)
 	var err error
-	org, err := cmd.Flags().GetString("org")
-	if err != nil {
-		log.Fatal(err)
-	}
 	username, err := cmd.Flags().GetString("username")
 	if err != nil {
 		log.Fatal(err)
@@ -60,9 +56,8 @@ func runLogin(cmd *cobra.Command, args []string) {
 		fmt.Println("")
 	}
 	res, status := request.SendRequestToEngine(http.MethodPost, "/users/login", map[string]interface{}{
-		"Username":     username,
-		"Password":     password,
-		"Organization": org,
+		"Username": username,
+		"Password": password,
 	})
 	if status == http.StatusOK {
 		fmt.Println("login success")
@@ -90,7 +85,6 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// loginCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-	loginCmd.Flags().String("org", "", "Organization name")
-	loginCmd.Flags().String("username", "", "Username")
-	loginCmd.Flags().String("password", "", "Password")
+	loginCmd.Flags().StringP("username", "u", "", "Username")
+	loginCmd.Flags().StringP("password", "p", "", "Password")
 }

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -1,0 +1,51 @@
+/*
+Copyright © 2023 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/sath-run/engine/cli/request"
+	"github.com/spf13/cobra"
+)
+
+// runCmd represents the run command
+var runCmd = &cobra.Command{
+	Use:   "run",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: runEngine,
+}
+
+func runEngine(cmd *cobra.Command, args []string) {
+	res, code := request.SendRequestToEngine(http.MethodPost, "/services/start", nil)
+	if code == http.StatusUnauthorized {
+		fmt.Println("login is required to run sath engine")
+		return
+	} else if code != http.StatusOK {
+		log.Fatal(res, code)
+	}
+	fmt.Println("successfully run sath-engine")
+}
+
+func init() {
+	rootCmd.AddCommand(runCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// runCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// runCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cli/cmd/shutdown.go
+++ b/cli/cmd/shutdown.go
@@ -4,12 +4,8 @@ Copyright © 2022 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"os"
-	"os/exec"
-	"strconv"
-	"strings"
 
 	"github.com/sath-run/engine/cli/request"
 	"github.com/spf13/cobra"
@@ -25,24 +21,10 @@ and will no longer start new jobs`,
 	Run: runShutdown,
 }
 
-func findRunningDaemonPid() (pid int, err error) {
-	command := exec.Command("bash", "-c", "ps | grep sath-engine | grep -v grep")
-	res, err := command.Output()
-	if err != nil {
-		err = errors.New("cannot find the running pid of sath")
-		return
-	}
-	pid, err = strconv.Atoi(strings.Fields(string(res))[0])
-	if err != nil {
-		return
-	}
-	return
-}
-
 func runShutdown(cmd *cobra.Command, args []string) {
 	resp := request.EnginePost("/services/stop", map[string]interface{}{"wait": true})
 	fmt.Println(resp["message"])
-	pid, err := findRunningDaemonPid()
+	pid, err := request.FindRunningDaemonPid()
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/cli/cmd/startup.go
+++ b/cli/cmd/startup.go
@@ -39,29 +39,15 @@ func startEngine() {
 		log.Fatal(err)
 	}
 	time.Sleep(time.Second)
-	if ok := testSathEnginePing(); ok {
+	if ok := request.PingSathEngine(); ok {
 		log.Println("sath engine successfully started")
 	} else {
-		if pid, _ := findRunningDaemonPid(); pid != 0 {
+		if pid, _ := request.FindRunningDaemonPid(); pid != 0 {
 			log.Fatalf("fail to ping sath engine: %s", buf.String())
 		} else {
 			log.Fatalf("fail to start sath engine: %s", buf.String())
 		}
 	}
-}
-
-func testSathEnginePing() bool {
-	for i := 0; i < 3; i++ {
-		time.Sleep(time.Second)
-		// ping sath-engine to make sure it is started
-		if request.Ping() {
-			return true
-		} else {
-			continue
-		}
-	}
-
-	return false
 }
 
 func checkIfUpgradeNeeded() (bool, string) {
@@ -92,9 +78,9 @@ func checkIfUpgradeNeeded() (bool, string) {
 }
 
 func runStartup(cmd *cobra.Command, args []string) {
-	if pid, _ := findRunningDaemonPid(); pid != 0 {
+	if pid, _ := request.FindRunningDaemonPid(); pid != 0 {
 		fmt.Println("Sath engine is running")
-		if !testSathEnginePing() {
+		if !request.PingSathEngine() {
 			log.Fatalf("fail to ping sath engine")
 		}
 	} else {
@@ -108,7 +94,6 @@ func runStartup(cmd *cobra.Command, args []string) {
 			startEngine()
 		}
 	}
-	request.EnginePost("/services/start", nil)
 }
 
 func init() {

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/sath-run/engine/cli/request"
+	"github.com/sath-run/engine/constants"
 	"github.com/spf13/cobra"
 )
 
@@ -19,16 +20,15 @@ var statusCmd = &cobra.Command{
 }
 
 func printStatusResult(result map[string]interface{}) {
-	fmt.Println("SATH Version:", result["version"])
 	var status string = result["status"].(string)
 	switch status {
 	case "WAITING":
-		fmt.Println("SATH Engine is waiting")
-		fmt.Println("  use: `sath start` to start it")
+		fmt.Println("sath-engine is waiting")
+		fmt.Println("  use `sath run` to run jobs")
 	case "UNINITIALIZED", "STARTING":
-		fmt.Println("SATH Engine is starting, it may take a few seconds")
+		fmt.Println("sath-engine is starting, it may take a few seconds")
 	case "RUNNING":
-		fmt.Println("SATH Engine is running")
+		fmt.Println("sath-engine is running")
 		if jobs, ok := result["jobs"].([]interface{}); ok {
 			fmt.Println("Current running jobs:")
 			fmt.Println("*****************************************")
@@ -38,27 +38,30 @@ func printStatusResult(result map[string]interface{}) {
 				}
 			}
 			fmt.Println("*****************************************")
-			fmt.Println("Use: `sath jobs` to view detail of jobs")
+			fmt.Println("  use `sath jobs` to view detail of jobs")
 		} else {
 			fmt.Println("No job is accpeted yet")
 		}
 	default:
 		fmt.Println("unknown status, please contact service@sath.run for support")
 	}
-	// if result == nil {
-	// 	fmt.Println("no job is running")
-	// } else {
-	// 	fmt.Printf("id: %s\n", result["id"])
-	// 	fmt.Printf("status: %s\n", result["status"])
-	// 	fmt.Printf("progress: %f\n", result["progress"])
-	// 	fmt.Printf("message: %s\n", result["message"])
-	// 	fmt.Println()
-	// }
 }
 
 func runStatus(cmd *cobra.Command, args []string) {
-	result := request.EngineGet("/services/status")
-	printStatusResult(result)
+	fmt.Println("sath version:", constants.Version)
+	user := request.EngineGet("/users/info")
+	if email, ok := user["email"].(string); ok && len(email) > 0 {
+		fmt.Println("*****************************************")
+		fmt.Println("sath-engine is logged in by user:")
+		fmt.Println("email:", email)
+		fmt.Println("name: ", user["name"])
+		fmt.Println("*****************************************")
+	} else {
+		fmt.Println("no user is logged in")
+		fmt.Println("  use `sath login` to login your account")
+	}
+	status := request.EngineGet("/services/status")
+	printStatusResult(status)
 }
 
 func init() {

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -63,7 +63,7 @@ func upgradeExecutables() error {
 }
 
 func runUpgrade(cmd *cobra.Command, args []string) {
-	if pid, _ := findRunningDaemonPid(); pid != 0 {
+	if pid, _ := request.FindRunningDaemonPid(); pid != 0 {
 		fmt.Println("Sath engine is still running, please use shutdown it first")
 		return
 	}

--- a/cli/request/process.go
+++ b/cli/request/process.go
@@ -1,0 +1,24 @@
+package request
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func FindRunningDaemonPid() (pid int, err error) {
+	os.Getpid()
+	command := exec.Command("bash", "-c", "ps | grep sath-engine | grep -v grep | grep -v \"go run\"")
+	res, err := command.Output()
+	if err != nil {
+		err = errors.New("cannot find the running pid of sath")
+		return
+	}
+	pid, err = strconv.Atoi(strings.Fields(string(res))[0])
+	if err != nil {
+		return
+	}
+	return
+}

--- a/constants/error.go
+++ b/constants/error.go
@@ -1,0 +1,15 @@
+package constants
+
+import "errors"
+
+var ErrNil = errors.New("result is nil")
+
+func IsErrNil(err error) bool {
+	switch {
+	case
+		errors.Is(err, ErrNil):
+		return true
+	default:
+		return false
+	}
+}

--- a/engine/core/job.go
+++ b/engine/core/job.go
@@ -13,14 +13,14 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/pkg/errors"
-	"github.com/sath-run/engine/constants"
 	pb "github.com/sath-run/engine/engine/core/protobuf"
 	"github.com/sath-run/engine/engine/logger"
 	"google.golang.org/grpc/metadata"
 )
 
 var (
-	ErrNoJob = errors.New("No job")
+	ErrUnautherized = errors.New("Unautherized")
+	ErrNoJob        = errors.New("No job")
 )
 
 func JobStatusText(enum pb.EnumExecStatus) string {
@@ -215,11 +215,8 @@ func processOutputs(dir string, job *pb.JobGetResponse) ([]*pb.ExecOutput, error
 	return outputs, nil
 }
 
-func RunSingleJob(ctx context.Context, orgId string) error {
-	job, err := g.grpcClient.GetNewJob(ctx, &pb.JobGetRequest{
-		Version:        constants.Version,
-		OrganizationId: orgId,
-	})
+func RunSingleJob(ctx context.Context) error {
+	job, err := g.grpcClient.GetNewJob(ctx, &pb.JobGetRequest{})
 
 	if err != nil {
 		return err

--- a/engine/core/protobuf/engine.proto
+++ b/engine/core/protobuf/engine.proto
@@ -21,21 +21,19 @@ message HandShakeRequest {
 
 message HandShakeResponse {
   string token = 1;
-  string user_id = 2;
-  string device_id = 3;
+  string device_id = 2;
 }
 
 message LoginRequest {
-  string password = 1;
-  string account = 2;
-  string organization = 3;
+  string account = 1;
+  string password = 2;
 }
 
 message LoginResponse {
   string token = 1;
   string user_id = 2;
-  string device_id = 3;
-  string organization_id = 4;
+  string user_name = 3;
+  string user_email = 4;
 }
 
 enum EnumCommand {

--- a/engine/core/protobuf/job.proto
+++ b/engine/core/protobuf/job.proto
@@ -18,10 +18,6 @@ enum EnumExecStatus {
 }
 
 message JobGetRequest {
-  string version = 1;
-  string project_id = 2;
-  string organization_id = 3;
-  string user_id = 4;
 }
 
 enum GpuOpt {

--- a/engine/logger/logger.go
+++ b/engine/logger/logger.go
@@ -13,6 +13,7 @@ import (
 
 var jobLogger *lumberjack.Logger
 var errLogger *lumberjack.Logger
+var stdLogger *lumberjack.Logger
 
 func Init() error {
 	loggerDir := filepath.Join(utils.ExecutableDir, "/log")
@@ -27,7 +28,14 @@ func Init() error {
 		Compress:   false, // disabled by default
 	}
 	errLogger = &lumberjack.Logger{
-		Filename:   filepath.Join(loggerDir, "jobs.log"),
+		Filename:   filepath.Join(loggerDir, "err.log"),
+		MaxSize:    20,    // megabytes
+		MaxBackups: 3,     //
+		MaxAge:     28,    //days
+		Compress:   false, // disabled by default
+	}
+	stdLogger = &lumberjack.Logger{
+		Filename:   filepath.Join(loggerDir, "out.log"),
 		MaxSize:    20,    // megabytes
 		MaxBackups: 3,     //
 		MaxAge:     28,    //days
@@ -55,7 +63,7 @@ func Debug(a ...any) {
 			time.Now().Format("2006/01/02 - 15:04:05"),
 			" | ")
 		messages = append(messages, a...)
-		fmt.Println(messages...)
+		stdLogger.Write([]byte(fmt.Sprintln(messages...)))
 	}
 }
 
@@ -66,7 +74,7 @@ func Warning(a ...any) {
 		time.Now().Format("2006/01/02 - 15:04:05"),
 		" | ")
 	messages = append(messages, a...)
-	fmt.Println(messages...)
+	stdLogger.Write([]byte(fmt.Sprintln(messages...)))
 }
 
 func LogJob(content []byte) {

--- a/engine/sath-engine.go
+++ b/engine/sath-engine.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sath-run/engine/engine/core"
 	"github.com/sath-run/engine/engine/logger"
 	"github.com/sath-run/engine/engine/server"
+	"github.com/sath-run/engine/meta"
 )
 
 var dataPath string
@@ -34,6 +35,10 @@ func main() {
 
 	if err := logger.Init(); err != nil {
 		log.Fatalf("fail to init logger, %+v\n", err)
+	}
+
+	if err := meta.Init(); err != nil {
+		log.Fatalf("fail to init DB, %+v\n", err)
 	}
 
 	sockfile := "/var/run/sath.sock"

--- a/engine/server/routes.go
+++ b/engine/server/routes.go
@@ -43,7 +43,7 @@ func Init(file string) {
 	r.POST("/jobs/resume", ResumeJob)
 	r.POST("/users/login", Login)
 	r.POST("/users/logout", Logout)
-	r.GET("/users/credential", GetCredential)
+	r.GET("/users/info", GetUserInfo)
 
 	if err := r.RunUnix(file); err != nil {
 		panic(err)

--- a/engine/server/service.go
+++ b/engine/server/service.go
@@ -10,6 +10,11 @@ import (
 )
 
 func StartService(c *gin.Context) {
+	if core.GetUserInfo() == nil {
+		// login is required
+		c.AbortWithStatusJSON(http.StatusUnauthorized, "login is required")
+		return
+	}
 	err := core.Start()
 	if errors.Is(err, core.ErrRunning) {
 		c.JSON(http.StatusOK, gin.H{

--- a/engine/server/user.go
+++ b/engine/server/user.go
@@ -11,14 +11,13 @@ import (
 
 func Login(c *gin.Context) {
 	var form struct {
-		Username     string `binding:"required"`
-		Password     string `binding:"required"`
-		Organization string ``
+		Username string `binding:"required"`
+		Password string `binding:"required"`
 	}
 	if err := c.Bind(&form); fatal(c, err) {
 		return
 	}
-	if err := core.Login(form.Username, form.Password, form.Organization); err != nil {
+	if err := core.Login(form.Username, form.Password); err != nil {
 		if st, ok := status.FromError(err); ok {
 			if st.Code() == codes.InvalidArgument {
 				c.JSON(http.StatusBadRequest, gin.H{
@@ -37,12 +36,16 @@ func Login(c *gin.Context) {
 	c.Status(http.StatusOK)
 }
 
-func GetCredential(c *gin.Context) {
-	credential := core.Credential()
-	c.JSON(http.StatusOK, gin.H{
-		"username":     credential.Username,
-		"organization": credential.Organization,
-	})
+func GetUserInfo(c *gin.Context) {
+	info := core.GetUserInfo()
+	if info == nil {
+		c.JSON(http.StatusOK, gin.H{})
+	} else {
+		c.JSON(http.StatusOK, gin.H{
+			"email": info.Email,
+			"name":  info.Name,
+		})
+	}
 }
 
 func Logout(c *gin.Context) {

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/shirou/gopsutil/v3 v3.22.10
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.1
+	go.etcd.io/bbolt v1.3.8
 	golang.org/x/term v0.15.0
 	google.golang.org/grpc v1.59.0
 	google.golang.org/protobuf v1.31.0

--- a/go.sum
+++ b/go.sum
@@ -170,6 +170,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yusufpapurcu/wmi v1.2.2 h1:KBNDSne4vP5mbSWnJbO+51IMOXJB67QiYCSBrubbPRg=
 github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+go.etcd.io/bbolt v1.3.8 h1:xs88BrvEv273UsB79e0hcVrlUWmS0a8upikMFhSyAtA=
+go.etcd.io/bbolt v1.3.8/go.mod h1:N9Mkw9X8x5fupy0IKsmuqVtoGDyxsaDlbk4Rd05IAQw=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/multierr v1.9.0 h1:7fIwc/ZtS0q++VgcfqFDxSBZVv/Xo49/SYnDFupUwlI=

--- a/meta/buckets.go
+++ b/meta/buckets.go
@@ -1,0 +1,49 @@
+package meta
+
+import bolt "go.etcd.io/bbolt"
+
+var (
+	bucketKeyVersion    = []byte(schemaVersion)
+	bucketKeyDBVersion  = []byte("version") // stores the version of the schema
+	bucketKeyCredential = []byte("credential")
+
+	bucketKeyUserToken   = []byte("usertoken")
+	bucketKeyDeviceToken = []byte("devicetoken")
+)
+
+func getBucket(tx *bolt.Tx, keys ...[]byte) *bolt.Bucket {
+	bkt := tx.Bucket(keys[0])
+
+	for _, key := range keys[1:] {
+		if bkt == nil {
+			break
+		}
+		bkt = bkt.Bucket(key)
+	}
+
+	return bkt
+}
+
+func createBucketIfNotExists(tx *bolt.Tx, keys ...[]byte) (*bolt.Bucket, error) {
+	bkt, err := tx.CreateBucketIfNotExists(keys[0])
+	if err != nil {
+		return nil, err
+	}
+
+	for _, key := range keys[1:] {
+		bkt, err = bkt.CreateBucketIfNotExists(key)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return bkt, nil
+}
+
+func credentialBucketPath() [][]byte {
+	return [][]byte{bucketKeyVersion, bucketKeyCredential}
+}
+
+func getCredentialBucket(tx *bolt.Tx) *bolt.Bucket {
+	return getBucket(tx, credentialBucketPath()...)
+}

--- a/meta/credential.go
+++ b/meta/credential.go
@@ -1,0 +1,47 @@
+package meta
+
+import (
+	"github.com/sath-run/engine/constants"
+	bolt "go.etcd.io/bbolt"
+)
+
+func getCredentialValue(key []byte) (string, error) {
+	var token string
+	err := db.View(func(tx *bolt.Tx) error {
+		bkt := getCredentialBucket(tx)
+		v := bkt.Get(key)
+		token = string(v)
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	if token == "" {
+		return "", constants.ErrNil
+	}
+	return token, nil
+}
+
+func setCredentialValue(key []byte, value string) error {
+	err := db.Update(func(tx *bolt.Tx) error {
+		bkt := getCredentialBucket(tx)
+		return bkt.Put(key, []byte(value))
+	})
+	return err
+}
+
+func GetCredentialUserToken() (string, error) {
+	return getCredentialValue(bucketKeyUserToken)
+}
+
+func SetCredentialUserToken(token string) error {
+	return setCredentialValue(bucketKeyUserToken, token)
+}
+
+func GetCredentialDeviceToken() (string, error) {
+	return getCredentialValue(bucketKeyDeviceToken)
+}
+
+func SetCredentialDeviceToken(token string) error {
+	return setCredentialValue(bucketKeyDeviceToken, token)
+}

--- a/meta/db.go
+++ b/meta/db.go
@@ -1,0 +1,104 @@
+package meta
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"path/filepath"
+
+	"github.com/sath-run/engine/utils"
+	bolt "go.etcd.io/bbolt"
+)
+
+const (
+	// schemaVersion represents the schema version of
+	// the database. This schema version represents the
+	// structure of the data in the database. The schema
+	// can envolve at any time but any backwards
+	// incompatible changes or structural changes require
+	// bumping the schema version.
+	schemaVersion = "v0"
+
+	// dbVersion represents updates to the schema
+	// version which are additions and compatible with
+	// prior version of the same schema.
+	dbVersion = 1
+)
+
+type DB struct {
+	db *bolt.DB
+}
+
+var db *DB
+
+func Init() error {
+	options := *bolt.DefaultOptions
+
+	// Reading bbolt's freelist sometimes fails when the file has a data corruption.
+	// Disabling freelist sync reduces the chance of the breakage.
+	// https://github.com/etcd-io/bbolt/pull/1
+	// https://github.com/etcd-io/bbolt/pull/6
+	options.NoFreelistSync = true
+
+	path := filepath.Join(utils.ExecutableDir, "meta.db")
+	bdb, err := bolt.Open(path, 0644, &options)
+	if err != nil {
+		return err
+	}
+	db = NewDB(bdb)
+	if err := db.Init(context.TODO()); err != nil {
+		return err
+	}
+	err = db.Update(func(tx *bolt.Tx) error {
+		if _, err := createBucketIfNotExists(tx, credentialBucketPath()...); err != nil {
+			return err
+		}
+		return nil
+	})
+	return err
+}
+
+func NewDB(db *bolt.DB) *DB {
+	return &DB{db: db}
+}
+
+func (m *DB) Init(ctx context.Context) error {
+	err := m.db.Update(func(tx *bolt.Tx) error {
+		bkt, err := tx.CreateBucketIfNotExists(bucketKeyVersion)
+		if err != nil {
+			return err
+		}
+
+		versionEncoded, err := encodeInt(dbVersion)
+		if err != nil {
+			return err
+		}
+
+		return bkt.Put(bucketKeyDBVersion, versionEncoded)
+	})
+	return err
+}
+
+func encodeInt(i int64) ([]byte, error) {
+	var (
+		buf      [binary.MaxVarintLen64]byte
+		iEncoded = buf[:]
+	)
+	iEncoded = iEncoded[:binary.PutVarint(iEncoded, i)]
+
+	if len(iEncoded) == 0 {
+		return nil, fmt.Errorf("failed encoding integer = %v", i)
+	}
+	return iEncoded, nil
+}
+
+// View runs a readonly transaction on the metadata store.
+func (m *DB) View(fn func(*bolt.Tx) error) error {
+	return m.db.View(fn)
+}
+
+// Update runs a writable transaction on the metadata store.
+func (m *DB) Update(fn func(*bolt.Tx) error) error {
+	err := m.db.Update(fn)
+	return err
+}


### PR DESCRIPTION
Changes made by this PR:

1. Use [bbolt](https://github.com/etcd-io/bbolt) as the database to manage local data. The use of bbolt is heavily inspired by this [containerd repo](https://github.com/containerd/containerd/blob/main/metadata/db.go)
2. Store device handshake and user login credential in bbolt DB, and make a auto login on sath-engine startup
3. Remove the support for organization login mode
4. Remove the support for guest mode. To run jobs in sath-engine, login is requied.
5. Rename engine/main.go to engine/sath-engine.go, so that the process id of sath-engine can be easily found by 'ps' command on debug mode if sath-engine is started by 'go run sath-engine.go' command